### PR TITLE
Send periodic heartbeat for each connected device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Send a periodic heartbeat for every connected device.
+
 ## [0.11.0] - 2020-04-13
 
 ## [0.11.0-rc.1] - 2020-03-26

--- a/lib/astarte_vmq_plugin/config.ex
+++ b/lib/astarte_vmq_plugin/config.ex
@@ -22,6 +22,9 @@ defmodule Astarte.VMQ.Plugin.Config do
   Astarte.VMQ.Plugin
   """
 
+  # 1 hour
+  @default_heartbeat_interval_ms 60 * 60 * 1000
+
   @doc """
   Load the configuration and transform it if needed (since we are retrieving
   it from Erlang with Cuttlefish, the strings have to be converted to Elixir
@@ -93,6 +96,14 @@ defmodule Astarte.VMQ.Plugin.Config do
 
   def registry_mfa do
     Application.get_env(:astarte_vmq_plugin, :registry_mfa)
+  end
+
+  def heartbeat_interval_ms do
+    Application.get_env(
+      :astarte_vmq_plugin,
+      :heartbeat_interval_ms,
+      @default_heartbeat_interval_ms
+    )
   end
 
   defp normalize_opts_strings(amqp_options) do

--- a/priv/astarte_vmq_plugin.schema
+++ b/priv/astarte_vmq_plugin.schema
@@ -60,6 +60,11 @@
     {datatype, string}
   ]}.
 
+{mapping, "astarte_vmq_plugin.heartbeat_interval_ms", "astarte_vmq_plugin.heartbeat_interval_ms",
+  [
+    {datatype, integer}
+  ]}.
+
 {mapping, "astarte_rpc.amqp_connection.username", "astarte_rpc.amqp_connection_options.username", [
     {datatype, string}
   ]}.


### PR DESCRIPTION
Send an heartbeat to refresh device connection state and to allow DUP to handle
disconnections happened while VerneMQ was down.

Fix #13

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>