### PR TITLE
Dockerfile: move to root and enhance build process

### DIFF
--- a/.github/workflows/pr-container-build-workflow.yaml
+++ b/.github/workflows/pr-container-build-workflow.yaml
@@ -14,7 +14,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Building Docker Image
-      working-directory: ./docker
       env:
         CONTAINER_IMAGE_NAME: gh_actions_test
       run: docker build -t $CONTAINER_IMAGE_NAME:ci-test .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - Unreleased
+### Added
+- Enhance docker build process
+
 ## [0.11.0] - 2020-04-13
 
 ## [0.11.0-rc.1] - 2020-03-26

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,7 @@
 # Build with Elixir 1.5/OTP 20
-FROM elixir:1.8.1-slim as builder
-
-RUN apt-get -qq update && apt-get -qq install git build-essential libssl-dev curl
-
-RUN mix local.hex --force && \
-    mix local.rebar --force && \
-    mix hex.info
+FROM elixir:1.8.1 as builder
 
 WORKDIR /build
-ENV MIX_ENV prod
 
 # Let's start by building VerneMQ
 RUN git clone --branch 1.7.1 https://github.com/erlio/vernemq.git && \
@@ -16,22 +9,40 @@ RUN git clone --branch 1.7.1 https://github.com/erlio/vernemq.git && \
 		make rel && \
 		cd ..
 
-# Time for VerneMQ's Astarte plugin
-RUN git clone https://github.com/astarte-platform/astarte_vmq_plugin.git && \
-		cd astarte_vmq_plugin && \
-		mix deps.get && \
-		mix release --env=$MIX_ENV && \
-		cd ..
+RUN mix local.hex --force && \
+  mix local.rebar --force && \
+  mix hex.info
+
+ENV MIX_ENV prod
+
+# Pass --build-arg BUILD_ENV=dev to build a dev image
+ARG BUILD_ENV=prod
+
+ENV MIX_ENV=$BUILD_ENV
+
+# Cache elixir deps
+ADD mix.exs mix.lock astarte_vmq_plugin/
+RUN cd astarte_vmq_plugin && \
+  mix do deps.get, deps.compile && \
+  cd ..
+
+# Add all the rest
+ADD . astarte_vmq_plugin/
+
+# Build and release
+RUN cd astarte_vmq_plugin && \
+  mix do compile, release && \
+  cd ..
 
 # Copy the schema over
 RUN cp astarte_vmq_plugin/priv/astarte_vmq_plugin.schema vernemq/_build/default/rel/vernemq/share/schema/
 
 # Copy configuration files here - mainly because we want to keep the target image as small as possible
 # and avoid useless layers.
-COPY files/vm.args /build/vernemq/_build/default/rel/vernemq/etc/
-COPY files/vernemq.conf /build/vernemq/_build/default/rel/vernemq/etc/
-COPY bin/rand_cluster_node.escript /build/vernemq/_build/default/rel/vernemq/bin/
-COPY bin/vernemq.sh /build/vernemq/_build/default/rel/vernemq/bin/
+COPY docker/files/vm.args /build/vernemq/_build/default/rel/vernemq/etc/
+COPY docker/files/vernemq.conf /build/vernemq/_build/default/rel/vernemq/etc/
+COPY docker/bin/rand_cluster_node.escript /build/vernemq/_build/default/rel/vernemq/bin/
+COPY docker/bin/vernemq.sh /build/vernemq/_build/default/rel/vernemq/bin/
 RUN chmod +x /build/vernemq/_build/default/rel/vernemq/bin/vernemq.sh
 
 # Note: it is important to keep Debian versions in sync, or incompatibilities between libcrypto will happen
@@ -40,12 +51,15 @@ FROM debian:stretch-slim
 # Set the locale
 ENV LANG C.UTF-8
 
+# We have to redefine this here since it goes out of scope for each build stage
+ARG BUILD_ENV=prod
+
 # We need SSL, curl, iproute2 and jq - and to ensure /etc/ssl/astarte
 RUN apt-get -qq update && apt-get -qq install libssl1.1 curl jq iproute2 netcat && apt-get clean && mkdir -p /etc/ssl/astarte
 
 # Copy our built stuff (both are self-contained with their ERTS release)
 COPY --from=builder /build/vernemq/_build/default/rel/vernemq /opt/vernemq/
-COPY --from=builder /build/astarte_vmq_plugin/_build/prod/rel/astarte_vmq_plugin /opt/astarte_vmq_plugin/
+COPY --from=builder /build/astarte_vmq_plugin/_build/$BUILD_ENV/rel/astarte_vmq_plugin /opt/astarte_vmq_plugin/
 
 # Add the wait-for utility
 RUN cd /usr/bin && curl -O https://raw.githubusercontent.com/eficode/wait-for/master/wait-for && chmod +x wait-for && cd -


### PR DESCRIPTION
Copy the plugin from the current directory instead of using git clone. This way
we ensure we're building the correct version in every branch.
While we're at it, add the build optimizations that are already present in other
Dockerfiles.

Note that this requires a change of settins on Dockerhub.

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>