### PR TITLE
Write SSL configuration to vernemq.conf only if SSL is enabled

### DIFF
--- a/docker/bin/vernemq.sh
+++ b/docker/bin/vernemq.sh
@@ -81,7 +81,14 @@ EOF
     echo "erlang.distribution.port_range.maximum = 9109" >> /opt/vernemq/etc/vernemq.conf
     echo "listener.tcp.default = ${IP_ADDRESS}:1883" >> /opt/vernemq/etc/vernemq.conf
     if env | grep -q "VERNEMQ_ENABLE_SSL_LISTENER"; then
+        # Populate SSL config
         echo "listener.ssl.default = ${IP_ADDRESS}:8883" >> /opt/vernemq/etc/vernemq.conf
+        echo "listener.ssl.cafile = /opt/vernemq/etc/ca.pem" >> /opt/vernemq/etc/vernemq.conf
+        echo "listener.ssl.certfile = /opt/vernemq/etc/cert.pem" >> /opt/vernemq/etc/vernemq.conf
+        echo "listener.ssl.keyfile = /opt/vernemq/etc/privkey.pem" >> /opt/vernemq/etc/vernemq.conf
+        echo "listener.ssl.require_certificate = on" >> /opt/vernemq/etc/vernemq.conf
+        echo "listener.ssl.use_identity_as_username = on" >> /opt/vernemq/etc/vernemq.conf
+        echo "listener.ssl.tls_version = tlsv1.2" >> /opt/vernemq/etc/vernemq.conf
     fi
     # We enable the revproxy listener regardless.
     echo "listener.tcp.revproxy = ${IP_ADDRESS}:1885" >> /opt/vernemq/etc/vernemq.conf

--- a/docker/files/vernemq.conf
+++ b/docker/files/vernemq.conf
@@ -179,19 +179,6 @@ listener.max_connections = infinity
 ##   - an integer
 listener.nr_of_acceptors = 10
 
-# LISTENERS: Have everything on 0.0.0.0 and let Kubernetes handle port
-# access and forwarding.
-listener.ssl.cafile = /opt/vernemq/etc/ca.pem
-listener.ssl.certfile = /opt/vernemq/etc/cert.pem
-listener.ssl.keyfile = /opt/vernemq/etc/privkey.pem
-# listener.ssl.ciphers = 
-# TODO: How to handle crl with Kubernetes?
-# listener.ssl.crlfile = 
-listener.ssl.require_certificate = on
-listener.ssl.use_identity_as_username = on
-# Force tlsv1.2
-listener.ssl.tls_version = tlsv1.2
-
 # Reverse proxy listener
 listener.tcp.revproxy.proxy_protocol = on
 # FIXME: Enable when merged


### PR DESCRIPTION
Fix crash when an instance that was not using SSL (e.g. on Kubernetes) was
brought up.

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>