### PR TITLE
Default max certificate chain length to 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 ### Added
 - Send a periodic heartbeat for every connected device.
+- Support SSL for RabbitMQ connections.
+- Default max certificate chain length to 10.
 
 ## [0.11.1] - Unreleased
 ### Added

--- a/lib/astarte_vmq_plugin/config.ex
+++ b/lib/astarte_vmq_plugin/config.ex
@@ -85,7 +85,10 @@ defmodule Astarte.VMQ.Plugin.Config do
   end
 
   defp populate_sni(amqp_ssl, amqp_options) do
-    [verify: :verify_peer]
+    [
+      verify: :verify_peer,
+      depth: 10
+    ]
     |> set_sni_value(amqp_ssl, amqp_options)
   end
 


### PR DESCRIPTION
The erlang default of 1 is too strict. Increase the default value to 10
to make it coincident to OpenSSL default.