### PR TITLE
Reply to publish requests with local and remote matches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Send a periodic heartbeat for every connected device.
 - Support SSL for RabbitMQ connections.
 - Default max certificate chain length to 10.
+- Reply with local and remote matches when a publish is requested.
 
 ## [0.11.1] - Unreleased
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,11 @@ WORKDIR /build
 RUN apt-get -qq update && apt-get -qq install libsnappy-dev
 
 # Let's start by building VerneMQ
-RUN git clone --branch 1.10.2 https://github.com/erlio/vernemq.git && \
+# TODO: use a stable version as soon as 1.10.3 is released
+# for now build from master since we need https://github.com/vernemq/vernemq/pull/1518
+RUN git clone https://github.com/erlio/vernemq.git && \
 		cd vernemq && \
+		git checkout a4fd2180036a55bed586244c97e66c380b51411e && \
 		make rel && \
 		cd ..
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "amqp": {:hex, :amqp, "1.4.2", "4181290cda65d35b757460e87b3023486b080fdf6560d3e38e288e23bd2a0b3d", [:mix], [{:amqp_client, "~> 3.8.0", [hex: :amqp_client, repo: "hexpm", optional: false]}], "hexpm", "080ab24601ef503d930fce28f913ac996e5f29fe6c91ce21a4f6d1f5aa6017b6"},
   "amqp_client": {:hex, :amqp_client, "3.8.3", "11d4825d56e77bafb246631a5c68b5c245567f6cc6331c4ddaa3f55fa39c9e8a", [:make, :rebar3], [{:rabbit_common, "3.8.3", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm", "987124a9cf2373d16e0ce8143d8b167548a532826ce80e53ea7b8d959d6a0e5e"},
-  "astarte_rpc": {:git, "https://github.com/astarte-platform/astarte_rpc.git", "186bd1c03f1bfedfe0c1f6dc3d4d3cb6c6f495de", []},
+  "astarte_rpc": {:git, "https://github.com/astarte-platform/astarte_rpc.git", "8400d76d938ab09064322721746ebf8810d4dfae", []},
   "castore": {:hex, :castore, "0.1.5", "591c763a637af2cc468a72f006878584bc6c306f8d111ef8ba1d4c10e0684010", [:mix], [], "hexpm", "6db356b2bc6cc22561e051ff545c20ad064af57647e436650aa24d7d06cd941a"},
   "certifi": {:hex, :certifi, "2.5.1", "867ce347f7c7d78563450a18a6a28a8090331e77fa02380b4a21962a65d36ee5", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm", "805abd97539caf89ec6d4732c91e62ba9da0cda51ac462380bbd28ee697a8c42"},
   "credentials_obfuscation": {:hex, :credentials_obfuscation, "1.1.0", "513793cc20c18afc9e03e584b436192a751a8344890e03a8741c65c8d6866fab", [:rebar3], [], "hexpm", "2d1bc574d129ff76309a03874c245193c6375bc766734e008888e636b250d5df"},

--- a/test/astarte_vmq_plugin_rpc_test.exs
+++ b/test/astarte_vmq_plugin_rpc_test.exs
@@ -22,8 +22,8 @@ defmodule Astarte.VMQ.Plugin.RPCTest do
   alias Astarte.RPC.Protocol.VMQ.Plugin.{
     Call,
     GenericErrorReply,
-    GenericOkReply,
     Publish,
+    PublishReply,
     Reply
   }
 
@@ -148,8 +148,8 @@ defmodule Astarte.VMQ.Plugin.RPCTest do
     assert %Reply{
              version: 0,
              reply: {
-               :generic_ok_reply,
-               %GenericOkReply{}
+               :publish_reply,
+               %PublishReply{}
              }
            } = Reply.decode(ser_reply)
 


### PR DESCRIPTION
Allow the caller to react based on the actual number of clients that will (eventually) receive the published data