### PR TITLE
Remove explicit persistency defaults, allow to configure them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support SSL for RabbitMQ connections.
 - Default max certificate chain length to 10.
 - Reply with local and remote matches when a publish is requested.
+- Allow configuring `max_offline_messages` and `persistent_client_expiration` with Docker env
+  variables
 
 ## [0.11.1] - Unreleased
 ### Added

--- a/docker/files/vernemq.conf
+++ b/docker/files/vernemq.conf
@@ -79,7 +79,7 @@ allow_multiple_sessions = off
 ##   - text
 # Astarte: 1 week is reasonable to have another full handshake - don't put too much pressure
 # on disk.
-persistent_client_expiration = 1w
+# persistent_client_expiration = 1w
 
 ## The maximum number of QoS 1 or 2 messages that can be in the process of being
 ## transmitted simultaneously. This includes messages currently going through handshakes
@@ -116,7 +116,7 @@ max_online_messages = 1000
 ## 
 ## Acceptable values:
 ##   - an integer
-max_offline_messages = 1000
+# max_offline_messages = 1000
 
 ## This option sets the maximum MQTT size that VerneMQ will
 ## allow.  Messages that exceed this size will not be accepted by


### PR DESCRIPTION
With https://github.com/astarte-platform/astarte/pull/386 AppEngine now
makes sure the message gets delivered to the device before returning
200.
persistent_client_expiration and max_offline_messages influence this
behavior, since they limit the lifetime and quantity of messages that
will be delivered to the device.
Therefore, these values are made tunable via the docker env vars
mechanism.

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>