### PR TITLE
Allow empty payload in publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.11.3] - Unreleased
+### Fixed
+- Fix bug that prevented property unset
+
 ## [0.11.2] - 2020-08-14
 ### Added
 - Update Elixir to 1.8.2

--- a/lib/astarte_vmq_plugin/rpc/handler.ex
+++ b/lib/astarte_vmq_plugin/rpc/handler.ex
@@ -73,11 +73,6 @@ defmodule Astarte.VMQ.Plugin.RPC.Handler do
     generic_error(:empty_topic_tokens, "empty topic tokens")
   end
 
-  defp call_rpc({:publish, %Publish{payload: ""}}) do
-    Logger.warn("Publish with empty payload")
-    generic_error(:payload_is_empty, "payload is \"\"")
-  end
-
   # This also handles the case of qos == nil, that is > 2
   defp call_rpc({:publish, %Publish{qos: qos}}) when qos > 2 or qos < 0 do
     Logger.warn("Publish with invalid QoS")

--- a/test/astarte_vmq_plugin_rpc_test.exs
+++ b/test/astarte_vmq_plugin_rpc_test.exs
@@ -67,39 +67,6 @@ defmodule Astarte.VMQ.Plugin.RPCTest do
     assert MockVerne.consume_message() == nil
   end
 
-  test "invalid payload Publish call" do
-    serialized_call =
-      %Call{
-        version: 0,
-        call: {
-          :publish,
-          %Publish{
-            topic_tokens: @topic,
-            payload: nil,
-            qos: 2
-          }
-        }
-      }
-      |> Call.encode()
-
-    assert {:ok, ser_reply} = Handler.handle_rpc(serialized_call)
-
-    assert %Reply{
-             version: 0,
-             reply: {
-               :generic_error_reply,
-               %GenericErrorReply{
-                 error_name: "payload_is_empty",
-                 user_readable_error_name: "",
-                 user_readable_message: "payload is \"\"",
-                 error_data: ""
-               }
-             }
-           } = Reply.decode(ser_reply)
-
-    assert MockVerne.consume_message() == nil
-  end
-
   test "invalid qos Publish call" do
     serialized_call =
       %Call{


### PR DESCRIPTION
With the old protobufs, the default value for not-set payload for nil, which was
an invalid one. When converting to Protobuf 3 with
02b97b8999e28aabb8b47934fa6c11071897ccd4 the default value changed from nil to
an empty string, but an empty string is effectively a valid payload (e.g. for an
unset message), so we have to remove the clause marking the value as invalid.

Fixes https://github.com/astarte-platform/astarte/issues/460

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>