### PR TITLE
Start the plugin OTP application as permanent

### DIFF
--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -39,7 +39,7 @@ jobs:
         key: ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-dialyzer_cache-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-dialyzer_cache-
-    - uses: actions/setup-elixir@v1.2.0
+    - uses: actions/setup-elixir@v1.5.0
       with:
         otp-version: ${{ env.otp_version }}
         elixir-version: ${{ env.elixir_version }}
@@ -83,7 +83,7 @@ jobs:
         key: ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-_build-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-_build-
-    - uses: actions/setup-elixir@v1.2.0
+    - uses: actions/setup-elixir@v1.5.0
       with:
         otp-version: ${{ env.otp_version }}
         elixir-version: ${{ env.elixir_version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.11.4] - Unreleased
+### Fixed
+- Fix a bug where the plugin would remain unfunctional after suddenly disconnecting from RabbitMQ.
+
 ## [0.11.3] - 2020-09-24
 ### Fixed
 - Fix bug that prevented property unset

--- a/mix.exs
+++ b/mix.exs
@@ -25,6 +25,7 @@ defmodule Astarte.VMQ.Plugin.Mixfile do
       version: "0.11.3",
       elixir: "~> 1.8",
       elixirc_paths: elixirc_paths(Mix.env()),
+      erlc_paths: ["src"],
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],
       preferred_cli_env: [

--- a/src/astarte_vmq_plugin.erl
+++ b/src/astarte_vmq_plugin.erl
@@ -1,0 +1,34 @@
+%%
+%% This file is part of Astarte
+%%
+%% Copyright 2021 Ispirata Srl
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+
+-module(astarte_vmq_plugin).
+-export([start/0, stop/0]).
+
+start() ->
+    % We want to start the plugin as permanent to make sure that if the plugin
+    % application crashes, VerneMQ comes down with it (and gets restarted by
+    % K8s).
+    % To do so, we need to define this erlang wrapper since right now VerneMQ
+    % assumes the custom start function is contained in a module with the same
+    % name as the application, which can't be an Elixir module due to naming
+    % constraints.
+    {ok, _} = application:ensure_all_started(astarte_vmq_plugin, permanent),
+    ok.
+
+stop() ->
+    application:stop(astarte_vmq_plugin).


### PR DESCRIPTION
We want to start the plugin as permanent to make sure that if the plugin application crashes, VerneMQ comes down with it (and gets restarted by K8s).
To do so, we need to define an erlang wrapper since right now VerneMQ assumes the custom start function is contained in a module with the same name as the application, which can't be an Elixir module due to naming constraints.
This should fix the situations where VerneMQ was not able to publish after a RabbitMQ disconnection causing a plugin crash.

Signed-off-by: Riccardo Binetti <riccardo.binetti@ispirata.com>