### PR TITLE
Do not authorize non-devices blindly in auth_on_publish and auth_on_subscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.0-beta.2] - Unreleased
 ### Changed
 - Update Elixir to 1.11.3 and Erlang/OTP to 23.2
+- Do not authorize non-devices blindly in `auth_on_publish` and `auth_on_subscribe`.
 
 ## [1.0.0-beta.1] - 2021-02-16
 ### Changed

--- a/lib/astarte_vmq_plugin.ex
+++ b/lib/astarte_vmq_plugin.ex
@@ -59,9 +59,9 @@ defmodule Astarte.VMQ.Plugin do
         _isretain
       ) do
     cond do
-      # Not a device, authorizing everything
+      # Not a device, let someone else decide
       !String.contains?(client_id, "/") ->
-        :ok
+        :next
 
       # Device auth
       String.split(client_id, "/") == Enum.take(topic_tokens, 2) ->
@@ -74,7 +74,8 @@ defmodule Astarte.VMQ.Plugin do
 
   def auth_on_subscribe(_username, {_mountpoint, client_id}, topics) do
     if !String.contains?(client_id, "/") do
-      :ok
+      # Not a device, let someone else decide
+      :next
     else
       client_id_tokens = String.split(client_id, "/")
 

--- a/test/astarte_vmq_plugin_test.exs
+++ b/test/astarte_vmq_plugin_test.exs
@@ -128,7 +128,7 @@ defmodule Astarte.VMQ.PluginTest do
       {["and", "so", "on"], 2}
     ]
 
-    assert :ok = Plugin.auth_on_subscribe(:dontcare, {:dontcare, @other_mqtt_user}, topics)
+    assert :next = Plugin.auth_on_subscribe(:dontcare, {:dontcare, @other_mqtt_user}, topics)
   end
 
   test "authorized auth_on_publish for device" do
@@ -209,7 +209,7 @@ defmodule Astarte.VMQ.PluginTest do
     control_topic = [@realm, @device_id, "control", "some", "path"]
     random_topic = ["any", "topic"]
 
-    assert :ok =
+    assert :next =
              Plugin.auth_on_publish(
                :dontcare,
                {:dontcare, @other_mqtt_user},
@@ -219,7 +219,7 @@ defmodule Astarte.VMQ.PluginTest do
                :dontcare
              )
 
-    assert :ok =
+    assert :next =
              Plugin.auth_on_publish(
                :dontcare,
                {:dontcare, @other_mqtt_user},
@@ -229,7 +229,7 @@ defmodule Astarte.VMQ.PluginTest do
                :dontcare
              )
 
-    assert :ok =
+    assert :next =
              Plugin.auth_on_publish(
                :dontcare,
                {:dontcare, @other_mqtt_user},
@@ -239,7 +239,7 @@ defmodule Astarte.VMQ.PluginTest do
                :dontcare
              )
 
-    assert :ok =
+    assert :next =
              Plugin.auth_on_publish(
                :dontcare,
                {:dontcare, @other_mqtt_user},


### PR DESCRIPTION
Fix #1 . 
Now the Plugin returns `:next` instead of `:ok `in `auth_on_publish` and `auth_on_subscribe` when the username doesn't contain a `/ `(and so it is not considered a device). 