### PR TITLE
Remove `max_message_rate` from `auth_on_register` return tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - Unreleased
+### Fixed
+- Do not override VerneMQ config `max_message_rate` value.
+
 ## [1.0.0] - 2021-06-30
 ### Changed
 - Log plugin version when the application is starting.

--- a/lib/astarte_vmq_plugin.ex
+++ b/lib/astarte_vmq_plugin.ex
@@ -42,7 +42,6 @@ defmodule Astarte.VMQ.Plugin do
        [
          subscriber_id: subscriber_id,
          max_inflight_messages: 100,
-         max_message_rate: 10000,
          max_message_size: 65535,
          retry_interval: 20000,
          upgrade_qos: false


### PR DESCRIPTION
Do not override the `max_message_rate` value from VMQ config in the return tuple of `auth_on_register`.