### PR TITLE
Fail if the CA cert cannot be retrieved from CFSSL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - Unreleased
+### Fixed
+- Do not let VerneMQ container start unless the CA cert is retrieved from CFSSL.
+
 ## [1.0.3] - 2022-04-07
 
 ## [1.0.2] - 2022-03-30

--- a/docker/bin/vernemq.sh
+++ b/docker/bin/vernemq.sh
@@ -101,10 +101,12 @@ fi
 
 if env | grep -q "VERNEMQ_ENABLE_SSL_LISTENER"; then
     # Let's do our magic. First of all, let's ask for certificates.
-    if ! curl -s -d '{"label": "primary"}' -X POST $CFSSL_URL/api/v1/cfssl/info | jq -e -r ".result.certificate" > /etc/ssl/cfssl-ca-cert.crt; then
+    cacert=$(curl -s -d '{"label": "primary"}' -X POST $CFSSL_URL/api/v1/cfssl/info | jq -e -r ".result.certificate")
+    if [ -z "$cacert" ]; then
         echo "Could not retrieve certificate from CFSSL at $CFSSL_URL , exiting"
-        exit $?
+        exit 1
     fi
+    echo "$cacert" > /etc/ssl/cfssl-ca-cert.crt
     if env | grep -q "USE_LETSENCRYPT"; then
         # TODO: Make this rotate in case we're using Let's encrypt
         echo "You have chosen Let's encrypt as the deploy mechanism - this means clustering Verne is impossible!"


### PR DESCRIPTION
The vernemq container isn't allowed to start unless the ca cert is
obtained from cfssl.