### PR TITLE
Add a patch to increase SSL handshake timeout in VerneMQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.4] - Unreleased
 ### Fixed
 - Do not let VerneMQ container start unless the CA cert is retrieved from CFSSL.
+- Prevent the connection from timing out when the client takes more than 5 seconds to perform the
+  SSL handshake
 
 ## [1.0.3] - 2022-04-07
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,14 @@ RUN apt-get -qq update && apt-get -qq install libsnappy-dev
 # See https://github.blog/2021-09-01-improving-git-protocol-security-github/
 RUN git config --global url.https://.insteadOf git://
 
-RUN git clone https://github.com/vernemq/vernemq.git -b 1.11.0 && \
-		cd vernemq && \
-		make rel && \
-		cd ..
+RUN git clone https://github.com/vernemq/vernemq.git -b 1.11.0
+
+COPY docker/patches/increase_ssl_handshake_timeout.patch /build/vernemq/
+
+RUN cd vernemq && \
+  git apply increase_ssl_handshake_timeout.patch && \
+  make rel && \
+  cd ..
 
 RUN mix local.hex --force && \
   mix local.rebar --force && \

--- a/docker/patches/increase_ssl_handshake_timeout.patch
+++ b/docker/patches/increase_ssl_handshake_timeout.patch
@@ -1,0 +1,12 @@
+diff --git a/apps/vmq_server/src/vmq_ranch_config.erl b/apps/vmq_server/src/vmq_ranch_config.erl
+index 7acc18e..2b6ca44 100644
+--- a/apps/vmq_server/src/vmq_ranch_config.erl
++++ b/apps/vmq_server/src/vmq_ranch_config.erl
+@@ -132,6 +132,7 @@ start_listener(Type, Addr, Port, {TransportOpts, Opts}) ->
+     TransportOptions = maps:from_list(
+         [{socket_opts, [{ip, AAddr}, {port, Port}|TransportOpts]},
+          {num_acceptors, NrOfAcceptors},
++         {handshake_timeout, 30000},
+          {max_connections, MaxConns}]),
+     case ranch:start_listener(Ref, TransportMod, TransportOptions,
+                               protocol_for_type(Type),


### PR DESCRIPTION
This is a temporary workaround to allow constrained devices that take more than 5 seconds to perform the SSL handshake to connect to the broker without timing out.

See https://github.com/vernemq/vernemq/issues/1670 for the related issue, this will be reverted once the configuration for the handshake timeout is exposed in VerneMQ

Signed-off-by: Riccardo Binetti <riccardo.binetti@secomind.com>