### PR TITLE
Fix order of disconnection and connection events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Correctly serialize disconnection/reconnection events if VerneMQ hooks are called in
+  the wrong order. Fix https://github.com/astarte-platform/astarte/issues/668.
+
 ## [1.0.4] - 2022-09-26
 ### Fixed
 - Do not let VerneMQ container start unless the CA cert is retrieved from CFSSL.

--- a/lib/astarte_vmq_plugin/application.ex
+++ b/lib/astarte_vmq_plugin/application.ex
@@ -39,6 +39,8 @@ defmodule Astarte.VMQ.Plugin.Application do
     # List all child processes to be supervised
     children = [
       Astarte.VMQ.Plugin.AMQPClient,
+      {Registry, keys: :unique, name: AstarteVMQPluginConnectionSynchronizer.Registry},
+      Astarte.VMQ.Plugin.Connection.Synchronizer.Supervisor,
       {Astarte.VMQ.Plugin.Publisher, [Config.registry_mfa()]},
       {Astarte.RPC.AMQP.Server, [amqp_queue: Protocol.amqp_queue(), handler: RPCHandler]}
     ]

--- a/lib/astarte_vmq_plugin/connection/synchronizer.ex
+++ b/lib/astarte_vmq_plugin/connection/synchronizer.ex
@@ -1,0 +1,171 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.VMQ.Plugin.Connection.Synchronizer do
+  @moduledoc """
+    This module handles connection and disconnection events. As it may happen that
+    VerneMQ hooks are called in the wrong order if events occur in a delta of ~10 ms,
+    the module forces the correct order of publication (i.e. disconnection before reconnection).
+    See https://github.com/vernemq/vernemq/issues/1741.
+  """
+  alias Astarte.VMQ.Plugin
+  @behaviour :gen_statem
+
+  # Hooks might be called in the wrong order if the time difference is ~10 ms.
+  # Let's play it safe with 50 ms.
+  @timeout_ms 50
+
+  defmodule Data do
+    defstruct [
+      :client_id,
+      :connection_headers,
+      :connection_timestamp,
+      :disconnection_headers,
+      :disconnection_timestamp
+    ]
+  end
+
+  # API
+
+  @impl true
+  def callback_mode() do
+    [:state_functions]
+  end
+
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]},
+      type: :worker,
+      restart: :transient
+    }
+  end
+
+  def start_link(opts) do
+    client_id = Keyword.fetch!(opts, :client_id)
+    name = via_tuple(client_id)
+
+    with {:ok, pid} <- :gen_statem.start_link(name, __MODULE__, opts, []) do
+      {:ok, pid}
+    end
+  end
+
+  def handle_connection(pid, timestamp, additional_headers \\ []) do
+    :gen_statem.cast(pid, {:connection, timestamp, additional_headers})
+  end
+
+  def handle_disconnection(pid, timestamp, additional_headers \\ []) do
+    :gen_statem.cast(pid, {:disconnection, timestamp, additional_headers})
+  end
+
+  # Callbacks
+
+  @impl true
+  def init(init_args) do
+    client_id = Keyword.fetch!(init_args, :client_id)
+    data = %Data{client_id: client_id}
+    {:ok, :accept, data}
+  end
+
+  def accept(:cast, {:connection, timestamp, additional_headers}, data) do
+    new_data = %{data | connection_timestamp: timestamp, connection_headers: additional_headers}
+
+    {:next_state, :has_connection, new_data, [timeout_action()]}
+  end
+
+  def accept(:cast, {:disconnection, timestamp, additional_headers}, data) do
+    new_data = %{
+      data
+      | disconnection_timestamp: timestamp,
+        disconnection_headers: additional_headers
+    }
+
+    {:next_state, :has_disconnection, new_data, [timeout_action()]}
+  end
+
+  def has_connection(
+        :cast,
+        {:disconnection, disconnection_timestamp, disconnection_headers},
+        %Data{
+          client_id: client_id,
+          connection_timestamp: connection_timestamp,
+          connection_headers: connection_headers
+        }
+      ) do
+    Plugin.publish_event(
+      client_id,
+      "disconnection",
+      disconnection_timestamp,
+      disconnection_headers
+    )
+
+    Plugin.publish_event(client_id, "connection", connection_timestamp, connection_headers)
+
+    {:stop, :normal}
+  end
+
+  def has_connection(:timeout, _content, data) do
+    Plugin.publish_event(
+      data.client_id,
+      "connection",
+      data.connection_timestamp,
+      data.connection_headers
+    )
+
+    {:stop, :normal}
+  end
+
+  def has_disconnection(:cast, {:connection, connection_timestamp, connection_headers}, %Data{
+        client_id: client_id,
+        disconnection_timestamp: disconnection_timestamp,
+        disconnection_headers: disconnection_headers
+      }) do
+    Plugin.publish_event(
+      client_id,
+      "disconnection",
+      disconnection_timestamp,
+      disconnection_headers
+    )
+
+    Plugin.publish_event(client_id, "connection", connection_timestamp, connection_headers)
+    {:stop, :normal}
+  end
+
+  def has_disconnection(:timeout, _content, data) do
+    Plugin.publish_event(
+      data.client_id,
+      "disconnection",
+      data.disconnection_timestamp,
+      data.disconnection_headers
+    )
+
+    {:stop, :normal}
+  end
+
+  def via_tuple(client_id) do
+    {:via, Registry, {AstarteVMQPluginConnectionSynchronizer.Registry, client_id}}
+  end
+
+  defp timeout_action() do
+    {
+      :timeout,
+      @timeout_ms,
+      nil
+    }
+  end
+end

--- a/lib/astarte_vmq_plugin/connection/synchronizer/synchronizer_supervisor.ex
+++ b/lib/astarte_vmq_plugin/connection/synchronizer/synchronizer_supervisor.ex
@@ -1,0 +1,39 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.VMQ.Plugin.Connection.Synchronizer.Supervisor do
+  # TODO a single dynamic supervisor may become a bottleneck,
+  # use a PartitionSupervisor when on Elixir >= 1.14
+  use DynamicSupervisor
+
+  alias Astarte.VMQ.Plugin.Connection.Synchronizer
+
+  def start_link(init_arg) do
+    DynamicSupervisor.start_link(__MODULE__, init_arg, name: __MODULE__)
+  end
+
+  @impl true
+  def init(_init_arg) do
+    DynamicSupervisor.init(strategy: :one_for_one)
+  end
+
+  def start_child(opts) do
+    spec = Synchronizer.child_spec(opts)
+    DynamicSupervisor.start_child(__MODULE__, spec)
+  end
+end

--- a/test/astarte_vmq_plugin_connection_synchronizer_test.exs
+++ b/test/astarte_vmq_plugin_connection_synchronizer_test.exs
@@ -1,0 +1,224 @@
+#
+# This file is part of Astarte.
+#
+# Copyright 2022 SECO Mind Srl
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+defmodule Astarte.VMQ.Plugin.Connection.SynchronizerTest do
+  use ExUnit.Case
+
+  alias AMQP.{Channel, Connection, Queue}
+  alias Astarte.VMQ.Plugin.Config
+  alias Astarte.VMQ.Plugin.Connection.Synchronizer
+  alias Astarte.VMQ.Plugin.Connection.Synchronizer.Supervisor, as: SynchronizerSupervisor
+
+  @device_id :crypto.strong_rand_bytes(16) |> Base.url_encode64(padding: false)
+  @realm "test"
+  @device_base_path "#{@realm}/#{@device_id}"
+  @queue_name "#{Config.data_queue_prefix()}0"
+
+  setup_all do
+    amqp_opts = Config.amqp_options()
+    {:ok, conn} = Connection.open(amqp_opts)
+    {:ok, chan} = Channel.open(conn)
+    Queue.declare(chan, @queue_name)
+    {:ok, chan: chan}
+  end
+
+  setup %{chan: chan} do
+    test_pid = self()
+
+    {:ok, consumer_tag} =
+      Queue.subscribe(chan, @queue_name, fn payload, meta ->
+        send(test_pid, {:amqp_msg, payload, meta})
+      end)
+
+    on_exit(fn ->
+      Queue.unsubscribe(chan, consumer_tag)
+    end)
+
+    :ok
+  end
+
+  test "Standard connection flow" do
+    connection_timestamp = now_us_x10_timestamp()
+
+    # no reconciler
+    assert Registry.lookup(AstarteVMQPluginConnectionSynchronizer.Registry, @device_base_path) ==
+             []
+
+    # start the reconciler
+    reconciler_pid = get_connection_reconciler_process!(@device_base_path)
+
+    assert Registry.lookup(AstarteVMQPluginConnectionSynchronizer.Registry, @device_base_path) ==
+             [
+               {reconciler_pid, nil}
+             ]
+
+    # connect the device
+    Synchronizer.handle_connection(reconciler_pid, connection_timestamp)
+
+    # Make sure messages arrived
+    Process.sleep(100)
+
+    # the reconciler should be dead by now
+    assert Registry.lookup(AstarteVMQPluginConnectionSynchronizer.Registry, @device_base_path) ==
+             []
+
+    assert_receive {:amqp_msg, "",
+                    %{headers: connection_headers, timestamp: ^connection_timestamp}}
+
+    assert %{"x_astarte_msg_type" => "connection"} = amqp_headers_to_map(connection_headers)
+  end
+
+  test "Ordered disconnection and reconnection events are correctly ordered" do
+    connection_timestamp = now_us_x10_timestamp()
+    disconnection_timestamp = connection_timestamp + 1
+    reconnection_timestamp = connection_timestamp + 2
+
+    # No reconciler
+    assert Registry.lookup(AstarteVMQPluginConnectionSynchronizer.Registry, @device_base_path) ==
+             []
+
+    # Start the reconciler
+    reconciler_pid = get_connection_reconciler_process!(@device_base_path)
+
+    assert Registry.lookup(AstarteVMQPluginConnectionSynchronizer.Registry, @device_base_path) ==
+             [
+               {reconciler_pid, nil}
+             ]
+
+    # Connect the device
+    Synchronizer.handle_connection(reconciler_pid, connection_timestamp)
+
+    # Make sure messages arrived
+    Process.sleep(100)
+
+    # The reconciler should be dead by now
+    assert Registry.lookup(AstarteVMQPluginConnectionSynchronizer.Registry, @device_base_path) ==
+             []
+
+    assert_receive {:amqp_msg, "",
+                    %{headers: connection_headers, timestamp: ^connection_timestamp}}
+
+    assert %{"x_astarte_msg_type" => "connection"} = amqp_headers_to_map(connection_headers)
+
+    # Now, another reconciler comes in hand
+    another_reconciler_pid = get_connection_reconciler_process!(@device_base_path)
+
+    # Correctly ordered events: disconnection before reconnectiom
+    Synchronizer.handle_disconnection(another_reconciler_pid, disconnection_timestamp)
+    Synchronizer.handle_connection(another_reconciler_pid, reconnection_timestamp)
+
+    # Make sure messages arrived
+    Process.sleep(100)
+
+    # The other reconciler should be dead, too, by now
+    assert Registry.lookup(AstarteVMQPluginConnectionSynchronizer.Registry, @device_base_path) ==
+             []
+
+    # Disconnect arrived before (re)connect
+    assert {:messages, [disconnect_message, reconnect_message]} = Process.info(self(), :messages)
+
+    assert {:amqp_msg, "", %{headers: disconnection_headers, timestamp: ^disconnection_timestamp}} =
+             disconnect_message
+
+    assert %{"x_astarte_msg_type" => "disconnection"} = amqp_headers_to_map(disconnection_headers)
+
+    assert {:amqp_msg, "", %{headers: reconnection_headers, timestamp: ^reconnection_timestamp}} =
+             reconnect_message
+
+    assert %{"x_astarte_msg_type" => "connection"} = amqp_headers_to_map(reconnection_headers)
+  end
+
+  test "Disconnection and reconnection events swapped, but near in time, are correctly reordered" do
+    connection_timestamp = now_us_x10_timestamp()
+    disconnection_timestamp = connection_timestamp + 1
+    reconnection_timestamp = connection_timestamp + 2
+
+    # No reconciler
+    assert Registry.lookup(AstarteVMQPluginConnectionSynchronizer.Registry, @device_base_path) ==
+             []
+
+    # Start the reconciler
+    reconciler_pid = get_connection_reconciler_process!(@device_base_path)
+
+    assert Registry.lookup(AstarteVMQPluginConnectionSynchronizer.Registry, @device_base_path) ==
+             [
+               {reconciler_pid, nil}
+             ]
+
+    # Connect the device
+    Synchronizer.handle_connection(reconciler_pid, connection_timestamp)
+
+    # Make sure messages arrived
+    Process.sleep(100)
+
+    # The reconciler should be dead by now
+    assert Registry.lookup(AstarteVMQPluginConnectionSynchronizer.Registry, @device_base_path) ==
+             []
+
+    assert_receive {:amqp_msg, "",
+                    %{headers: connection_headers, timestamp: ^connection_timestamp}}
+
+    assert %{"x_astarte_msg_type" => "connection"} = amqp_headers_to_map(connection_headers)
+
+    # Now, another reconciler comes in hand
+    another_reconciler_pid = get_connection_reconciler_process!(@device_base_path)
+
+    # Make some strange things à la VMQ, like a connection just before a disconnection
+    Synchronizer.handle_connection(another_reconciler_pid, reconnection_timestamp)
+    Synchronizer.handle_disconnection(another_reconciler_pid, disconnection_timestamp)
+
+    # Make sure messages arrived
+    Process.sleep(100)
+
+    # The other reconciler should be dead, too, by now
+    assert Registry.lookup(AstarteVMQPluginConnectionSynchronizer.Registry, @device_base_path) ==
+             []
+
+    # Disconnect arrived before (re)connect
+    assert {:messages, [disconnect_message, reconnect_message]} = Process.info(self(), :messages)
+
+    assert {:amqp_msg, "", %{headers: disconnection_headers, timestamp: ^disconnection_timestamp}} =
+             disconnect_message
+
+    assert %{"x_astarte_msg_type" => "disconnection"} = amqp_headers_to_map(disconnection_headers)
+
+    assert {:amqp_msg, "", %{headers: reconnection_headers, timestamp: ^reconnection_timestamp}} =
+             reconnect_message
+
+    assert %{"x_astarte_msg_type" => "connection"} = amqp_headers_to_map(reconnection_headers)
+  end
+
+  defp amqp_headers_to_map(headers) do
+    Enum.reduce(headers, %{}, fn {key, _type, value}, acc ->
+      Map.put(acc, key, value)
+    end)
+  end
+
+  defp now_us_x10_timestamp do
+    DateTime.utc_now()
+    |> DateTime.to_unix(:microsecond)
+    |> Kernel.*(10)
+  end
+
+  defp get_connection_reconciler_process!(client_id) do
+    case SynchronizerSupervisor.start_child(client_id: client_id) do
+      {:ok, pid} -> pid
+      {:error, {:already_started, pid}} -> pid
+    end
+  end
+end

--- a/test/astarte_vmq_plugin_test.exs
+++ b/test/astarte_vmq_plugin_test.exs
@@ -499,7 +499,12 @@ defmodule Astarte.VMQ.PluginTest do
     test "when on_register is called just before on_client_offline" do
       ip_addr = {2, 3, 4, 5}
 
-      Plugin.on_register({ip_addr, :dontcare}, {:dontcare, @device_base_path}, :dontcare)
+      Task.start(Plugin, :on_register, [
+        {ip_addr, :dontcare},
+        {:dontcare, @device_base_path},
+        :dontcare
+      ])
+
       # Call hook in another process, as VMQ does
       Task.start(Plugin, :on_client_offline, [{:dontcare, @device_base_path}])
 
@@ -553,7 +558,12 @@ defmodule Astarte.VMQ.PluginTest do
     test "when on_register is called just before on_client_gone" do
       ip_addr = {2, 3, 4, 5}
 
-      Plugin.on_register({ip_addr, :dontcare}, {:dontcare, @device_base_path}, :dontcare)
+      Task.start(Plugin, :on_register, [
+        {ip_addr, :dontcare},
+        {:dontcare, @device_base_path},
+        :dontcare
+      ])
+
       # Call hook in another process, as VMQ does
       Task.start(Plugin, :on_client_gone, [{:dontcare, @device_base_path}])
 
@@ -607,9 +617,15 @@ defmodule Astarte.VMQ.PluginTest do
     test "when on_client_offline is called before on_register" do
       ip_addr = {2, 3, 4, 5}
 
-      # Call hook in another process, as VMQ does, making sure it happens before on_register
-      Task.async(Plugin, :on_client_offline, [{:dontcare, @device_base_path}]) |> Task.await()
-      Plugin.on_register({ip_addr, :dontcare}, {:dontcare, @device_base_path}, :dontcare)
+      # Call hook in another process, as VMQ does
+      Task.start(Plugin, :on_client_offline, [{:dontcare, @device_base_path}])
+
+      # Call hook in another process, as VMQ does
+      Task.start(Plugin, :on_register, [
+        {ip_addr, :dontcare},
+        {:dontcare, @device_base_path},
+        :dontcare
+      ])
 
       # Make sure messages were received
       Process.sleep(100)
@@ -661,9 +677,15 @@ defmodule Astarte.VMQ.PluginTest do
     test "when on_client_gone is called before on_register" do
       ip_addr = {2, 3, 4, 5}
 
-      # Call hook in another process, as VMQ does, making sure it happens before on_register
-      Task.async(Plugin, :on_client_gone, [{:dontcare, @device_base_path}]) |> Task.await()
-      Plugin.on_register({ip_addr, :dontcare}, {:dontcare, @device_base_path}, :dontcare)
+      # Call hook in another process, as VMQ does
+      Task.start(Plugin, :on_client_gone, [{:dontcare, @device_base_path}])
+
+      # Call hook in another process, as VMQ does
+      Task.start(Plugin, :on_register, [
+        {ip_addr, :dontcare},
+        {:dontcare, @device_base_path},
+        :dontcare
+      ])
 
       # Make sure messages were received
       Process.sleep(100)


### PR DESCRIPTION
In rare corner cases (time difference < 10 ms), the `on_register` hook (reconnection) may be called before the related `on_client_offline/gone` hook (disconnection). This is due to the distributed nature of VerneMQ (see https://github.com/vernemq/vernemq/issues/1741), and results in an invalid device connection state in Astarte: a device may be publishing while being in a disconnected status.
Introduce a check on the order of disconnection/reconnection events, and possibly reorder them if such a corner case happens.
During reordering (at most 50ms), other kind of messages (if any) are retained in VMQ memory. 

Fix https://github.com/astarte-platform/astarte/issues/668.