### PR TITLE
Use the `internal` event type for device heartbeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.0-rc.0] - Unreleased
+### Changed
+- Use the `internal` event type for device heartbeat.
+
 ## [1.1.0-alpha.0] - 2022-11-24
 ### Fixed
 - Correctly serialize disconnection/reconnection events if VerneMQ hooks are called in

--- a/lib/astarte_vmq_plugin.ex
+++ b/lib/astarte_vmq_plugin.ex
@@ -224,9 +224,10 @@ defmodule Astarte.VMQ.Plugin do
   end
 
   defp publish_heartbeat(realm, device_id) do
+    additional_headers = [x_astarte_internal_path: "/heartbeat"]
     timestamp = now_us_x10_timestamp()
 
-    publish(realm, device_id, "", "heartbeat", timestamp)
+    publish(realm, device_id, "", "internal", timestamp, additional_headers)
   end
 
   defp publish(realm, device_id, payload, event_string, timestamp, additional_headers \\ []) do

--- a/test/astarte_vmq_plugin_test.exs
+++ b/test/astarte_vmq_plugin_test.exs
@@ -476,9 +476,10 @@ defmodule Astarte.VMQ.PluginTest do
 
     assert %{
              "x_astarte_vmqamqp_proto_ver" => 1,
-             "x_astarte_msg_type" => "heartbeat",
+             "x_astarte_msg_type" => "internal",
              "x_astarte_realm" => @realm,
-             "x_astarte_device_id" => @device_id
+             "x_astarte_device_id" => @device_id,
+             "x_astarte_internal_path" => "/heartbeat"
            } = amqp_headers_to_map(headers)
 
     assert String.starts_with?(message_id, message_id_prefix(@realm, @device_id, timestamp))


### PR DESCRIPTION
Drop the `heartbeat` message type for a more general one.