### PR TITLE
Bump Elixir, Erlang and VerneMQ 

### DIFF
--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -18,7 +18,7 @@ env:
 jobs:
   test-dialyzer:
     name: Check Dialyzer
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       MIX_ENV: ci
     steps:
@@ -39,7 +39,7 @@ jobs:
         key: ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-dialyzer_cache-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-dialyzer_cache-
-    - uses: erlef/setup-elixir@v1.7.0
+    - uses: erlef/setup-beam@v1.15
       with:
         otp-version: ${{ env.otp_version }}
         elixir-version: ${{ env.elixir_version }}
@@ -51,7 +51,7 @@ jobs:
 
   test-coverage:
     name: Build and Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # Wait for Dialyzer to give it a go before building
     needs:
       - test-dialyzer
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         rabbitmq:
-        - "rabbitmq:3.8.16-management"
+        - "rabbitmq:3.12.0-management"
     services:
       rabbitmq:
         image: ${{ matrix.rabbitmq }}
@@ -83,7 +83,7 @@ jobs:
         key: ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-_build-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-_build-
-    - uses: erlef/setup-elixir@v1.7.0
+    - uses: erlef/setup-beam@v1.15
       with:
         otp-version: ${{ env.otp_version }}
         elixir-version: ${{ env.elixir_version }}

--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -12,8 +12,8 @@ on:
   pull_request:
 
 env:
-  elixir_version: "1.11.4"
-  otp_version: "23.3"
+  elixir_version: "1.14.5"
+  otp_version: "25.3.2"
 
 jobs:
   test-dialyzer:

--- a/.github/workflows/pr-container-build-workflow.yaml
+++ b/.github/workflows/pr-container-build-workflow.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   test-build-container:
     name: Test Container Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Building Docker Image

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.11.4-otp-23
-erlang 23.2.7
+elixir 1.14.5-otp-25
+erlang 25.3.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.1.0-rc.0] - Unreleased
 ### Changed
 - Use the `internal` event type for device heartbeat.
+- Update Elixir to 1.14.5 and Erlang/OTP to 25.3.2.
 
 ## [1.1.0-alpha.0] - 2022-11-24
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.11.4-erlang-23.2.7-debian-buster-20210208 as builder
+FROM hexpm/elixir:1.14.5-erlang-25.3.2-debian-bullseye-20230522-slim as builder
 
 # install build dependencies
 # --allow-releaseinfo-change allows to pull from 'oldstable'
@@ -8,11 +8,11 @@ RUN apt-get update --allow-releaseinfo-change -y \
 
 WORKDIR /build
 
-# Needed for VerneMQ 1.12.6.1
+# Needed for VerneMQ 1.13.0
 RUN apt-get -qq update && apt-get -qq install libsnappy-dev libssl-dev
 
 # Let's start by building VerneMQ
-RUN git clone https://github.com/vernemq/vernemq.git -b 1.12.6.1
+RUN git clone https://github.com/vernemq/vernemq.git -b 1.13.0
 
 RUN cd vernemq && \
   make rel && \
@@ -55,7 +55,7 @@ COPY docker/bin/vernemq.sh /build/vernemq/_build/default/rel/vernemq/bin/
 RUN chmod +x /build/vernemq/_build/default/rel/vernemq/bin/vernemq.sh
 
 # Note: it is important to keep Debian versions in sync, or incompatibilities between libcrypto will happen
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 # Set the locale
 ENV LANG C.UTF-8

--- a/config/ci.exs
+++ b/config/ci.exs
@@ -1,1 +1,1 @@
-use Mix.Config
+import Config

--- a/config/config.exs
+++ b/config/config.exs
@@ -18,9 +18,9 @@
 
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 config :lager,
   handlers: [level: :critical]
 
-import_config "#{Mix.env()}.exs"
+import_config "#{config_env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-use Mix.Config
+import Config
 
 config :astarte_vmq_plugin, :registry_mfa, {Astarte.VMQ.Plugin.Utils, :empty_plugin_functions, []}
 

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-use Mix.Config
+import Config
 
 config :logger,
   compile_time_purge_matching: [

--- a/config/test.exs
+++ b/config/test.exs
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-use Mix.Config
+import Config
 
 # lager is used by rabbit_common.
 # Silent it by setting the higher loglevel.

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule Astarte.VMQ.Plugin.Mixfile do
     [
       app: :astarte_vmq_plugin,
       version: "1.1.0-alpha.0",
-      elixir: "~> 1.11",
+      elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       test_coverage: [tool: ExCoveralls],

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "amqp": {:hex, :amqp, "2.1.2", "eab047abb54f7e30022b81b9534b797e51c6e7756f1b112ec6dcee3c3ac20eac", [:mix], [{:amqp_client, "~> 3.8.0", [hex: :amqp_client, repo: "hexpm", optional: false]}], "hexpm", "535901c611a979221d045839e9e7a661bf33d04590b796c8fa30f487511fde04"},
   "amqp_client": {:hex, :amqp_client, "3.8.35", "e81dbec62057155b5aff857ac9ee85a63af2baf6e0fd4e9d02a3aff46a3de836", [:make, :rebar3], [{:rabbit_common, "3.8.35", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm", "ca8066e8d12530e31a9879789bc44bb2a4877dcd2d4b65e56b3d301b5e727688"},
-  "astarte_rpc": {:git, "https://github.com/astarte-platform/astarte_rpc.git", "25130b1df6cf4a04a14caef9723e34de704b42ac", [branch: "release-1.1"]},
+  "astarte_rpc": {:git, "https://github.com/astarte-platform/astarte_rpc.git", "6327f40149aade7b80a1e56b2f91a5c9c28723ee", [branch: "release-1.1"]},
   "castore": {:hex, :castore, "0.1.19", "a2c3e46d62b7f3aa2e6f88541c21d7400381e53704394462b9fd4f06f6d42bb6", [:mix], [], "hexpm", "e96e0161a5dc82ef441da24d5fa74aefc40d920f3a6645d15e1f9f3e66bb2109"},
   "certifi": {:hex, :certifi, "2.9.0", "6f2a475689dd47f19fb74334859d460a2dc4e3252a3324bd2111b8f0429e7e21", [:rebar3], [], "hexpm", "266da46bdb06d6c6d35fde799bcb28d36d985d424ad7c08b5bb48f5b5cdd4641"},
   "credentials_obfuscation": {:hex, :credentials_obfuscation, "3.1.0", "2c405ea0c5db7b3344aa5a99f86c33e7b6ecea97d2cb613371e1cf0d192ef2c6", [:rebar3], [], "hexpm", "04884e62b1c6cdfba999d4d6b3e99bc0a59d5e439517bc5c01767255afb7b778"},


### PR DESCRIPTION
Bump Elixir and Erlang to 1.14.5 and 25.3.2, respectively. Contextually, fix formatting and remove deprecated `Mix.Config`.
Bump VerneMQ to 1.13.0.
Bump also base GH workflow tools.