### PR TITLE
feat(capabilities): `capabilities` topic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   the following env variable has been added:
   - `DOCKER_VERNEMQ_ASTARTE_VMQ_PLUGIN__ASTARTE_INSTANCE_ID`
   (defaults to ``)
+- Added support for `capabilities` message topic at `/<realm name>/<device name>/capabilities`
 
 ### Changed
 - Update Elixir to 1.15.7.

--- a/lib/astarte_vmq_plugin.ex
+++ b/lib/astarte_vmq_plugin.ex
@@ -151,6 +151,9 @@ defmodule Astarte.VMQ.Plugin do
           control_path = "/" <> Enum.join(control_path_tokens, "/")
           publish_control_message(realm, device_id, control_path, payload, timestamp)
 
+        [^realm, ^device_id, "capabilities"] ->
+          publish_capabilities(realm, device_id, payload, timestamp)
+
         [^realm, ^device_id, interface | path_tokens] ->
           path = "/" <> Enum.join(path_tokens, "/")
           publish_data(realm, device_id, interface, path, payload, timestamp)
@@ -205,6 +208,10 @@ defmodule Astarte.VMQ.Plugin do
     additional_headers = [x_astarte_interface: interface, x_astarte_path: path]
 
     publish(realm, device_id, payload, "data", timestamp, additional_headers)
+  end
+
+  defp publish_capabilities(realm, device_id, payload, timestamp) do
+    publish(realm, device_id, payload, "capabilities", timestamp)
   end
 
   defp publish_control_message(realm, device_id, control_path, payload, timestamp) do

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{
   "amqp": {:hex, :amqp, "3.3.0", "056d9f4bac96c3ab5a904b321e70e78b91ba594766a1fc2f32afd9c016d9f43b", [:mix], [{:amqp_client, "~> 3.9", [hex: :amqp_client, repo: "hexpm", optional: false]}], "hexpm", "8d3ae139d2646c630d674a1b8d68c7f85134f9e8b2a1c3dd5621616994b10a8b"},
   "amqp_client": {:hex, :amqp_client, "3.12.10", "dcc0d5d0037fa2b486c6eb8b52695503765b96f919e38ca864a7b300b829742d", [:make, :rebar3], [{:credentials_obfuscation, "3.4.0", [hex: :credentials_obfuscation, repo: "hexpm", optional: false]}, {:rabbit_common, "3.12.10", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm", "16a23959899a82d9c2534ed1dcf1fa281d3b660fb7f78426b880647f0a53731f"},
-  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "dc964b7d9b3a3a4e20127b763705d9e53bd88890", []},
+  "astarte_core": {:git, "https://github.com/astarte-platform/astarte_core.git", "ccb81bebb22bf2c2475f3f3e6d3778f185198b41", []},
   "astarte_rpc": {:git, "https://github.com/astarte-platform/astarte_rpc.git", "c0d77760fb12256a23a2d00e1a119496a089fa9d", []},
   "castore": {:hex, :castore, "1.0.7", "b651241514e5f6956028147fe6637f7ac13802537e895a724f90bf3e36ddd1dd", [:mix], [], "hexpm", "da7785a4b0d2a021cd1292a60875a784b6caef71e76bf4917bdee1f390455cf5"},
   "certifi": {:hex, :certifi, "2.9.0", "6f2a475689dd47f19fb74334859d460a2dc4e3252a3324bd2111b8f0429e7e21", [:rebar3], [], "hexpm", "266da46bdb06d6c6d35fde799bcb28d36d985d424ad7c08b5bb48f5b5cdd4641"},


### PR DESCRIPTION
Devices can publish on `<realm>/<device_id>/capabilities` a message which will be forwarded with message type `capabilities`. This in the context of astarte-platform/astarte#1049 and allows DUP to receive the appropriate messages