### PR TITLE
Setup CI for multi-arch builds

### DIFF
--- a/.github/workflows/publish-release-to-dockerhub-workflow.yaml
+++ b/.github/workflows/publish-release-to-dockerhub-workflow.yaml
@@ -30,6 +30,9 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
@@ -48,3 +51,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/.github/workflows/publish-snapshot-to-dockerhub-workflow.yaml
+++ b/.github/workflows/publish-snapshot-to-dockerhub-workflow.yaml
@@ -35,6 +35,9 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Compute tag name for snapshot images
         id: compute-tag
         run: |
@@ -60,3 +63,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.5-erlang-26.1-debian-bullseye-20230612-slim AS builder
+FROM --platform=${BUILDPLATFORM} hexpm/elixir:1.15.5-erlang-26.1-debian-bullseye-20230612-slim AS builder
 
 # install build dependencies
 # --allow-releaseinfo-change allows to pull from 'oldstable'
@@ -55,7 +55,7 @@ COPY docker/files/vernemq.conf vernemq/_build/default/rel/vernemq/etc/
 COPY docker/bin/rand_cluster_node.escript vernemq/_build/default/rel/vernemq/bin/
 
 # Note: it is important to keep Debian versions in sync, or incompatibilities between libcrypto will happen
-FROM debian:bullseye-slim
+FROM --platform=${BUILDPLATFORM} debian:bullseye-slim
 
 # Set the locale
 ENV LANG C.UTF-8


### PR DESCRIPTION
This change adds support for building the plugin targeting specific architectures.

The CI workflows are updated to setup buildx, a Docker CLI plugin for extended build capabilities with BuildKit, and to build multi-arch Docker images.
The targeted platforms are: linux/amd64 and linux/arm64.
