### PR TITLE
ci: fix deprecated cache

### DIFF
--- a/.github/workflows/build-workflow.yaml
+++ b/.github/workflows/build-workflow.yaml
@@ -4,8 +4,8 @@ on:
   # Run when pushing to stable branches
   push:
     branches:
-    - 'master'
-    - 'release-*'
+      - "master"
+      - "release-*"
   # Run on branch/tag creation
   create:
   # Run on pull requests
@@ -22,36 +22,36 @@ jobs:
     env:
       MIX_ENV: ci
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v1
-      with:
-        path: deps
-        key: ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
-    - uses: actions/cache@v1
-      with:
-        path: _build
-        key: ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-_build-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-_build-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
-    - id: plt_cache
-      uses: actions/cache@v1
-      with:
-        path: dialyzer_cache
-        key: ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-dialyzer_cache-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-dialyzer_cache-
-    - uses: erlef/setup-beam@v1.15
-      with:
-        otp-version: ${{ env.otp_version }}
-        elixir-version: ${{ env.elixir_version }}
-    - name: Install Dependencies
-      run: mix deps.get
-    - name: Create PLTs dir
-      if: ${{steps.plt_cache.outputs.cache-hit != 'true'}}
-      run: mkdir -p dialyzer_cache && mix dialyzer --plt
-    - name: Run dialyzer
-      # FIXME: This should be set to fail when dialyzer issues are fixed
-      run: mix dialyzer || exit 0
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v4
+        with:
+          path: deps
+          key: ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+      - uses: actions/cache@v4
+        with:
+          path: _build
+          key: ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-_build-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-_build-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+      - id: plt_cache
+        uses: actions/cache@v4
+        with:
+          path: dialyzer_cache
+          key: ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-dialyzer_cache-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-dialyzer_cache-
+      - uses: erlef/setup-beam@v1.15
+        with:
+          otp-version: ${{ env.otp_version }}
+          elixir-version: ${{ env.elixir_version }}
+      - name: Install Dependencies
+        run: mix deps.get
+      - name: Create PLTs dir
+        if: ${{steps.plt_cache.outputs.cache-hit != 'true'}}
+        run: mkdir -p dialyzer_cache && mix dialyzer --plt
+      - name: Run dialyzer
+        # FIXME: This should be set to fail when dialyzer issues are fixed
+        run: mix dialyzer || exit 0
 
   test-coverage:
     name: Build and Test
@@ -63,56 +63,56 @@ jobs:
       fail-fast: false
       matrix:
         rabbitmq:
-        - "rabbitmq:3.12.0-management"
+          - "rabbitmq:3.12.0-management"
         database:
-        - "cassandra:3.11.15"
-        - "scylladb/scylla:5.2.2"
+          - "cassandra:3.11.15"
+          - "scylladb/scylla:5.2.2"
     services:
       rabbitmq:
         image: ${{ matrix.rabbitmq }}
         ports:
-        - 5672:5672
-        - 15672:15672
+          - 5672:5672
+          - 15672:15672
       database:
         image: ${{ matrix.database }}
         ports:
-        - 9042:9042
+          - 9042:9042
     env:
       MIX_ENV: test
       RABBITMQ_HOST: localhost
       CASSANDRA_NODES: localhost
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v1
-      with:
-        path: deps
-        key: ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
-        restore-keys: |
-          ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-mix-
-    - uses: actions/cache@v1
-      with:
-        path: _build
-        key: ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-_build-${{ github.sha }}
-        restore-keys: |
-          ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-_build-
-    - uses: erlef/setup-beam@v1.15
-      with:
-        otp-version: ${{ env.otp_version }}
-        elixir-version: ${{ env.elixir_version }}
-    - name: Install Dependencies
-      run: mix deps.get
-    - name: Check formatting
-      run: mix format --check-formatted
-    - name: Compile
-      run: mix do compile
-    - name: Wait for Cassandra
-      run: |
-        npm install -g wait-for-cassandra
-        wait-for-cassandra -T 120000 -h $CASSANDRA_NODES
-    - name: Test and Coverage
-      run: mix coveralls.json  --exclude wip -o coverage_results
-    - name: Upload Coverage Results to CodeCov
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      run: |
-        bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v4
+        with:
+          path: deps
+          key: ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-mix-
+      - uses: actions/cache@v4
+        with:
+          path: _build
+          key: ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-_build-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.elixir_version }}-${{ env.otp_version }}-_build-
+      - uses: erlef/setup-beam@v1.15
+        with:
+          otp-version: ${{ env.otp_version }}
+          elixir-version: ${{ env.elixir_version }}
+      - name: Install Dependencies
+        run: mix deps.get
+      - name: Check formatting
+        run: mix format --check-formatted
+      - name: Compile
+        run: mix do compile
+      - name: Wait for Cassandra
+        run: |
+          npm install -g wait-for-cassandra
+          wait-for-cassandra -T 120000 -h $CASSANDRA_NODES
+      - name: Test and Coverage
+        run: mix coveralls.json  --exclude wip -o coverage_results
+      - name: Upload Coverage Results to CodeCov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN


### PR DESCRIPTION
[Cache `v1` is deprecated](https://github.com/orgs/community/discussions/148746)
Updates the cache CI action version to 4.