### PR TITLE
feat(docker): allow dynamic Erlang cookie via environment variable

### DIFF
--- a/docker/bin/vernemq.sh
+++ b/docker/bin/vernemq.sh
@@ -3,6 +3,11 @@
 IP_ADDRESS=$(ip -4 addr show ${DOCKER_NET_INTERFACE:-eth0} | grep -oE '[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}' | sed -e "s/^[[:space:]]*//" | head -n 1)
 IP_ADDRESS=${DOCKER_IP_ADDRESS:-${IP_ADDRESS}}
 
+# Customize the Erlang cookie if specified
+if env | grep "RELEASE_COOKIE" -q; then
+    sed -i.bak -r "s/-setcookie vmq/-setcookie ${RELEASE_COOKIE}/" /opt/vernemq/etc/vm.args
+fi
+
 # Ensure the Erlang node name is set correctly
 if env | grep "DOCKER_VERNEMQ_NODENAME" -q; then
     sed -i.bak -r "s/-name VerneMQ@.+/-name VerneMQ@${DOCKER_VERNEMQ_NODENAME}/" /opt/vernemq/etc/vm.args


### PR DESCRIPTION
This PR modifies the `vernemq.sh` entrypoint script to support dynamic configuration of the Erlang distribution cookie used for clustering VerneMQ nodes.

Key changes:
- The script now reads the `RELEASE_COOKIE` environment variable, if set, and injects it into the vm.args file at runtime.
- If `RELEASE_COOKIE` is not set, the behavior falls back to the default (previously set value `vmq` in vm.args), ensuring backward compatibility.

In our deployment architecture, each instance of Astarte (Elixir services + VerneMQ with the custom plugin) will require a possibly unique Erlang cookie to securely form a cluster between the Erlang nodes. This change enables per-instance configuration without modifying the Docker image or baked-in vm.args file.