### PR TITLE
fix: wrong supervisor behavior

### DIFF
--- a/lib/astarte_vmq_plugin/rpc/supervisor.ex
+++ b/lib/astarte_vmq_plugin/rpc/supervisor.ex
@@ -29,9 +29,8 @@ defmodule Astarte.VMQ.Plugin.RPC.Supervisor do
     opts = [{:name, __MODULE__} | opts]
 
     with {:ok, pid} <- Horde.DynamicSupervisor.start_link(__MODULE__, init_arg, opts) do
-      case Horde.Registry.lookup(Registry.VMQPluginRPC, :server) do
-        [] ->
-          _ = Horde.DynamicSupervisor.start_child(pid, Astarte.VMQ.Plugin.RPC.Server)
+      with [] <- Horde.Registry.lookup(Registry.VMQPluginRPC, :server) do
+        _ = Horde.DynamicSupervisor.start_child(pid, Astarte.VMQ.Plugin.RPC.Server)
       end
 
       {:ok, pid}


### PR DESCRIPTION
RPC supervisor crashed when another rpc serve was already present in the distributed registry. With this PR the RPC server starts if no other server are in the registry and otherwise nothing happens :+1: 