### PR TITLE
fix: ensure rpc server always starts

### DIFF
--- a/lib/astarte_vmq_plugin/rpc/server.ex
+++ b/lib/astarte_vmq_plugin/rpc/server.ex
@@ -32,7 +32,9 @@ defmodule Astarte.VMQ.Plugin.RPC.Server do
     name = {:via, Horde.Registry, {Registry.VMQPluginRPC, :server}}
     opts = Keyword.put(opts, :name, name)
 
-    GenServer.start_link(__MODULE__, args, opts)
+    with {:error, {:already_started, pid}} <- GenServer.start_link(__MODULE__, args, opts) do
+      {:ok, pid}
+    end
   end
 
   # Callbacks
@@ -126,7 +128,7 @@ defmodule Astarte.VMQ.Plugin.RPC.Server do
       ) do
     _ =
       Logger.warning(
-        "Received a :name_confict signal from the outer space, maybe a netsplit occurred? Gracefully shutting down.",
+        "Received a :name_conflict signal from the outer space, maybe a netsplit occurred? Gracefully shutting down.",
         tag: "RPC exit"
       )
 

--- a/lib/astarte_vmq_plugin/rpc/supervisor.ex
+++ b/lib/astarte_vmq_plugin/rpc/supervisor.ex
@@ -25,12 +25,24 @@ defmodule Astarte.VMQ.Plugin.RPC.Supervisor do
 
   use Horde.DynamicSupervisor
 
+  require Logger
+
   def start_link(init_arg, opts \\ []) do
     opts = [{:name, __MODULE__} | opts]
 
     with {:ok, pid} <- Horde.DynamicSupervisor.start_link(__MODULE__, init_arg, opts) do
-      with [] <- Horde.Registry.lookup(Registry.VMQPluginRPC, :server) do
-        _ = Horde.DynamicSupervisor.start_child(pid, Astarte.VMQ.Plugin.RPC.Server)
+      Horde.DynamicSupervisor.start_child(pid, Astarte.VMQ.Plugin.RPC.Server)
+      |> case do
+        :ignore ->
+          "RPC server: start ignored"
+          |> Logger.warning(tag: "rpc_not_started")
+
+        {:error, reason} ->
+          "RPC server: error during startup: #{inspect(reason)}"
+          |> Logger.warning(tag: "rpc_not_started")
+
+        ok ->
+          ok
       end
 
       {:ok, pid}


### PR DESCRIPTION
previously, we avoided adding the server as a child to the supervisor if a server existed already, leaving the job to horde to eventually create a consistent status between the supervisors.

now, we do the same while making sure the rpc server is always added as a child to the supervisor, so that it is not possible for it to just not start

fixed some typos while at it