### PR TITLE
chore: add rpc startup log

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -20,4 +20,6 @@
 # and its dependencies with the aid of the Mix.Config module.
 import Config
 
+config :logger, level: :debug
+
 import_config "#{config_env()}.exs"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -18,10 +18,7 @@
 
 import Config
 
-config :logger,
-  compile_time_purge_matching: [
-    [level_lower_than: :info]
-  ]
+config :logger, level: :info
 
 config :logger, :console,
   format: {PrettyLog.LogfmtFormatter, :format},

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -1,0 +1,24 @@
+import Config
+
+level = System.get_env("ASTARTE_LOG_LEVEL")
+
+if level do
+  allowed_levels = [
+    "emergency",
+    "alert",
+    "critical",
+    "error",
+    "warning",
+    "warn",
+    "notice",
+    "info",
+    "debug",
+    "all",
+    "none"
+  ]
+
+  if level not in allowed_levels,
+    do: raise(~s[Invalid value for ASTARTE_LOG_LEVEL: "#{level}"])
+
+  config :logger, level: String.to_existing_atom(level)
+end

--- a/lib/astarte_vmq_plugin/rpc/supervisor.ex
+++ b/lib/astarte_vmq_plugin/rpc/supervisor.ex
@@ -42,6 +42,9 @@ defmodule Astarte.VMQ.Plugin.RPC.Supervisor do
           |> Logger.warning(tag: "rpc_not_started")
 
         ok ->
+          "RPC server: started successfully: #{inspect(ok)}"
+          |> Logger.debug(tag: "rpc_started")
+
           ok
       end
 


### PR DESCRIPTION
same as data updater plant: useful to debug cases where the rpc doesn't actually start.

add runtime configurable log level