### PR TITLE
fix: allow rpc server horizontal scalability

### DIFF
--- a/lib/astarte_vmq_plugin/rpc/server.ex
+++ b/lib/astarte_vmq_plugin/rpc/server.ex
@@ -32,9 +32,7 @@ defmodule Astarte.VMQ.Plugin.RPC.Server do
     name = {:via, Horde.Registry, {Registry.VMQPluginRPC, :server}}
     opts = Keyword.put(opts, :name, name)
 
-    with {:error, {:already_started, pid}} <- GenServer.start_link(__MODULE__, args, opts) do
-      {:ok, pid}
-    end
+    GenServer.start_link(__MODULE__, args, opts)
   end
 
   # Callbacks

--- a/lib/astarte_vmq_plugin/rpc/supervisor.ex
+++ b/lib/astarte_vmq_plugin/rpc/supervisor.ex
@@ -30,25 +30,9 @@ defmodule Astarte.VMQ.Plugin.RPC.Supervisor do
   def start_link(init_arg, opts \\ []) do
     opts = [{:name, __MODULE__} | opts]
 
-    with {:ok, pid} <- Horde.DynamicSupervisor.start_link(__MODULE__, init_arg, opts) do
-      Horde.DynamicSupervisor.start_child(pid, Astarte.VMQ.Plugin.RPC.Server)
-      |> case do
-        :ignore ->
-          "RPC server: start ignored"
-          |> Logger.warning(tag: "rpc_not_started")
-
-        {:error, reason} ->
-          "RPC server: error during startup: #{inspect(reason)}"
-          |> Logger.warning(tag: "rpc_not_started")
-
-        ok ->
-          "RPC server: started successfully: #{inspect(ok)}"
-          |> Logger.debug(tag: "rpc_started")
-
-          ok
-      end
-
-      {:ok, pid}
+    with {:ok, supervisor_wrapper_pid} <-
+           Horde.DynamicSupervisor.start_link(__MODULE__, init_arg, opts) do
+      initialize_horde_supervisor(supervisor_wrapper_pid)
     end
   end
 
@@ -62,5 +46,65 @@ defmodule Astarte.VMQ.Plugin.RPC.Supervisor do
     ]
     |> Keyword.merge(init_arg)
     |> Horde.DynamicSupervisor.init()
+  end
+
+  defp initialize_horde_supervisor(supervisor_wrapper_pid) do
+    with {:ok, supervisor_pid} <- supervisor_pid(supervisor_wrapper_pid),
+         :ok <- start_rpc_server(supervisor_pid) do
+      {:ok, supervisor_wrapper_pid}
+    else
+      error ->
+        # the initialization completed with error, stop the supervisor wrapper
+        :ok = Horde.DynamicSupervisor.stop(supervisor_wrapper_pid)
+        error
+    end
+  end
+
+  defp start_rpc_server(supervisor) do
+    Horde.DynamicSupervisor.start_child(supervisor, Astarte.VMQ.Plugin.RPC.Server)
+    |> case do
+      {:ok, _pid} = ok ->
+        "RPC server: started successfully: #{inspect(ok)}"
+        |> Logger.debug(tag: "rpc_started")
+
+        :ok
+
+      {:ok, _pid, _info} = ok ->
+        "RPC server: started successfully: #{inspect(ok)}"
+        |> Logger.debug(tag: "rpc_started")
+
+        :ok
+
+      {:error, {:already_started, _pid}} = ok ->
+        "RPC server: already running: #{inspect(ok)}"
+        |> Logger.debug(tag: "rpc_started")
+
+        :ok
+
+      :ignore ->
+        "RPC server: start ignored"
+        |> Logger.warning(tag: "rpc_not_started")
+
+        {:error, :rpc_start_ignored}
+
+      {:error, reason} ->
+        "RPC server: error during startup: #{inspect(reason)}"
+        |> Logger.warning(tag: "rpc_not_started")
+
+        {:error, :rpc_start_error}
+    end
+  end
+
+  defp supervisor_pid(supervisor_wrapper_pid) do
+    supervisor_wrapper_pid
+    |> Horde.DynamicSupervisor.which_children()
+    |> Enum.find_value(fn {id, child, _type, _modules} ->
+      id == Horde.DynamicSupervisorImpl && child
+    end)
+    |> case do
+      nil -> {:error, :supervisor_impl_not_found}
+      pid when is_pid(pid) -> {:ok, pid}
+      child -> {:error, {:supervisor_impl_not_ready, child}}
+    end
   end
 end

--- a/test/astarte_vmq_plugin_rpc_test.exs
+++ b/test/astarte_vmq_plugin_rpc_test.exs
@@ -37,6 +37,13 @@ defmodule Astarte.VMQ.Plugin.RPCTest do
     }
   end
 
+  test "the rpc server is a child of the rpc supervisor", %{rpc_server: server} do
+    pid = GenServer.whereis(server)
+    children = Horde.DynamicSupervisor.which_children(Astarte.VMQ.Plugin.RPC.Supervisor)
+
+    assert [{_id, ^pid, _type, _modules}] = children
+  end
+
   describe "Publish call" do
     test "fails on empty topic", %{rpc_server: server} do
       data =


### PR DESCRIPTION
previously the rpc server was not started as a child to the dynamic
supervisor, but instead to its wrapper.

properly handle setup of the rpc to make the startup fail in case of
error.
